### PR TITLE
Support non-interactive configuration of url scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ You can use the Ruby script that is included in the Spotify iOS SDK Demo Project
 - [Download the Spotify iOS SDK](https://github.com/spotify/ios-sdk/releases)
 - Follow the instructions from the [Spotify iOS SDK beginner's tutorial](https://developer.spotify.com/technologies/spotify-ios-sdk/tutorial/).	
 
+
+## Non-interactive installation
+
+To avoid being prompted for the [custom URL scheme](http://bit.ly/1u11ZUz),
+you can alternatively provide it in an environment variable:
+```
+export CORDOVA_SPOTIFY_URL_SCHEME=somecustomscheme
+cordova plugin add com.timflapper.spotify
+```
+
+
 ## License
 
 [MIT](LICENSE)

--- a/install.sh
+++ b/install.sh
@@ -4,22 +4,25 @@ if [ "$PLUGIN_ENV" == "test" ]; then
   exit
 fi
 
-DEFAULT_SCHEME="spotify-cordova"
+if [ "$CORDOVA_SPOTIFY_URL_SCHEME" == "" ]
+then
+    DEFAULT_SCHEME="spotify-cordova"
 
-echo "The Spotify SDK Plugin needs a URL scheme for authentication."
-echo "See http://bit.ly/1u11ZUz for more information"
-printf "Specify your URL scheme [$DEFAULT_SCHEME]: "
+    echo "The Spotify SDK Plugin needs a URL scheme for authentication."
+    echo "See http://bit.ly/1u11ZUz for more information"
+    printf "Specify your URL scheme [$DEFAULT_SCHEME]: "
 
-read urlscheme
-
-if [ "$urlscheme" == "" ]; then
-  urlscheme="$DEFAULT_SCHEME"
+    read CORDOVA_SPOTIFY_URL_SCHEME
+    if [ "$CORDOVA_SPOTIFY_URL_SCHEME" == "" ]
+    then
+      CORDOVA_SPOTIFY_URL_SCHEME="$DEFAULT_SCHEME"
+    fi
 fi
 
 echo "Writing URL scheme to plugin.xml"
 
 mv plugins/com.timflapper.spotify/plugin.xml plugins/com.timflapper.spotify/plugin.bak.xml
-sed "s/{{URL_SCHEME}}/$urlscheme/g" plugins/com.timflapper.spotify/plugin.bak.xml > plugins/com.timflapper.spotify/plugin.xml
+sed "s/{{URL_SCHEME}}/$CORDOVA_SPOTIFY_URL_SCHEME/g" plugins/com.timflapper.spotify/plugin.bak.xml > plugins/com.timflapper.spotify/plugin.xml
 rm plugins/com.timflapper.spotify/plugin.bak.xml
 
 echo "Removing placeholder"


### PR DESCRIPTION
Example usage:

in custominstallscript.sh
```
CORDOVA_SPOTIFY_URL_SCHEME=somecustomscheme
cordova plugin add com.timflapper.spotify
```

If the env variable is not set, `install.sh` falls back to prompting as it did prior to this change

---

An alternative approach could be to use [Cordova plugin variables](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#link-variables), but I'm not sure how to keep the fallback to interactive prompt in that scenario.... Example:

installation with variable input:
`cordova plugin add twitter-connect-plugin --variable FABRIC_KEY=<Fabric API Key>`

usage in plugin.xml:
`<meta-data android:name="io.fabric.ApiKey" android:value="$FABRIC_KEY" />`

https://github.com/ManifestWebDesign/twitter-connect-plugin#add-plugin-to-your-cordova-app
https://github.com/ManifestWebDesign/twitter-connect-plugin/blob/master/plugin.xml#L31