### PR TITLE
Update SpotifyAudioPlayer.m

### DIFF
--- a/src/ios/SpotifyAudioPlayer.m
+++ b/src/ios/SpotifyAudioPlayer.m
@@ -107,7 +107,9 @@ static NSMutableDictionary *instances;
 
 -(void)audioStreaming:(SPTAudioStreamingController *)audioStreaming didChangeToTrack:(NSDictionary *)trackMetadata
 {
- [self dispatchEvent:@"trackChanged" withArguments:@[trackMetadata]];
+ if(trackMetadata != nil){
+  [self dispatchEvent:@"trackChanged" withArguments:@[trackMetadata]];
+ }
 }
 
 -(void)audioStreaming:(SPTAudioStreamingController *)audioStreaming didChangeVolume:(SPTVolume)volume


### PR DESCRIPTION
fixing occasional crash that occurs after track ends. didChangeToTrach was being pass a nill trackMetadata value.